### PR TITLE
[fix] 개인 정보 수정 페이지 - 수정2

### DIFF
--- a/apps/client/src/app/my-page/edit-profile/page.tsx
+++ b/apps/client/src/app/my-page/edit-profile/page.tsx
@@ -3,8 +3,7 @@
 import React, { useEffect } from "react";
 import dynamic from "next/dynamic";
 import { SocialType } from "@/enum/social.enum";
-import { getUserInfo } from "@/services/user";
-
+import { withAuth } from "@/components/HOC/withAuth";
 const Content = {
   input: dynamic(
     () => import("@/containers/my-page/edit-profile/EditProfile"),
@@ -16,17 +15,12 @@ const Content = {
 };
 
 const EditProfilePage = () => {
-  const dummyUser = {
-    name: "홍길동",
-    socialType: SocialType.Kakao,
-  };
+  // const dummyUser = {
+  //   name: "홍길동",
+  //   socialType: SocialType.Kakao,
+  // };
 
-  //   TODO: API연동 후 주석 제거
-  //   useEffect(() => {
-  //     getUserInfo().then((res) => setUserData(res.data));
-  //   });
-
-  return <>{<Content.input socialType={dummyUser.socialType} />}</>;
+  return <>{<Content.input />}</>;
 };
 
-export default EditProfilePage;
+export default withAuth(EditProfilePage);

--- a/apps/client/src/containers/my-page/edit-profile/EditProfile.tsx
+++ b/apps/client/src/containers/my-page/edit-profile/EditProfile.tsx
@@ -65,7 +65,7 @@ const EditProfileContainer = () => {
             height={100}
           />
         </div>
-        {user && user.socialType === SocialType.Kakao && (
+        {user && user.socialType === SocialType.Kakao.toUpperCase() && (
           <div className="flex items-center justify-center w-8 h-8 bg-[#FEE500] rounded-full ml-4">
             <Icon icon={KakaoSymbolLogo} className="w-6 h-6" />
           </div>

--- a/apps/client/src/hooks/form/useEditProfileForm.ts
+++ b/apps/client/src/hooks/form/useEditProfileForm.ts
@@ -1,7 +1,9 @@
 import { EditProfileInputForm } from "@/interface/my-page/edit-profile/edit.interface";
 import { useForm } from "react-hook-form";
+import useMe from "../useMe";
 
 export const useEditProfileForm = () => {
+  const { user } = useMe();
   const {
     register,
     handleSubmit,
@@ -10,7 +12,7 @@ export const useEditProfileForm = () => {
   } = useForm<EditProfileInputForm>({
     mode: "onChange",
     defaultValues: {
-      name: "",
+      name: user?.name ?? "",
       password: "",
       passwordConfirm: "",
     },

--- a/apps/client/src/hooks/useMe.ts
+++ b/apps/client/src/hooks/useMe.ts
@@ -1,6 +1,11 @@
 import { getRecentLogin, setRecentLogin } from "@/utils/recentLogin";
-import { removeTokens, setTokens } from "@/utils/token";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { removeTokens } from "@/utils/token";
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { HELPER_MESSAGES } from "@libs/utils/message";
 import { IS_DEV } from "@/lib/config/env";
@@ -16,6 +21,9 @@ interface UseMe {
   error: unknown;
   onLogout(): void;
   isLoading: boolean;
+  refetch: (
+    options?: RefetchOptions,
+  ) => Promise<QueryObserverResult<MyInfoResponse, Error>>;
 }
 
 const useMe = (): UseMe => {
@@ -63,6 +71,7 @@ const useMe = (): UseMe => {
     error,
     onLogout,
     isLoading,
+    refetch,
   };
 };
 

--- a/packages/libs/src/utils/message.ts
+++ b/packages/libs/src/utils/message.ts
@@ -1,68 +1,65 @@
 export const ERROR_MESSAGES = {
   /** 로그인 */
-  usernameRequired: "아이디를 입력해주세요.",
-  passwordRequired: "비밀번호를 입력해주세요.",
+  usernameRequired: '아이디를 입력해주세요.',
+  passwordRequired: '비밀번호를 입력해주세요.',
 
   /** 회원가입 */
-  emailInvalid: "이메일 형식이 올바르지 않습니다.",
-  emailRequired: "이메일을 입력해주세요.",
-  duplicateEmail: "이미 존재하는 회원입니다.",
-  passwordInvalid:
-    "비밀번호는 8~16자의 영문, 숫자, 특수문자를 포함해야 합니다.",
-  passwordConfirmInvalid: "비밀번호가 일치하지 않습니다.",
-  phoneNumberInvalid: "번호는 - 를 뺀 01012341234로 입력해주세요.",
-  phoneNumberRequired: "휴대전화 번호를 입력해주세요.",
-  phoneNumberResponseFailed: "휴대전화 인증번호가 틀렸습니다.",
-  phoneNumberCodeInvalid: "휴대전화 인증번호는 6자리의 숫자입니다.",
-  oauthRegisterFailed: "소셜 회원가입에 실패했습니다.",
+  emailInvalid: '이메일 형식이 올바르지 않습니다.',
+  emailRequired: '이메일을 입력해주세요.',
+  duplicateEmail: '이미 존재하는 회원입니다.',
+  passwordInvalid: '비밀번호는 8~16자의 영문, 숫자, 특수문자를 포함해야 합니다.',
+  passwordConfirmInvalid: '비밀번호가 일치하지 않습니다.',
+  phoneNumberInvalid: '번호는 - 를 뺀 01012341234로 입력해주세요.',
+  phoneNumberRequired: '휴대전화 번호를 입력해주세요.',
+  phoneNumberResponseFailed: '휴대전화 인증번호가 틀렸습니다.',
+  phoneNumberCodeInvalid: '휴대전화 인증번호는 6자리의 숫자입니다.',
+  oauthRegisterFailed: '소셜 회원가입에 실패했습니다.',
 
-  emailCodeSentFailed: "이메일 인증번호 전송에 실패했습니다.",
-  emailCodeInvalid: "이메일 인증번호는 6자리의 숫자입니다.",
-  emailCodeRequired: "이메일 인증번호를 입력해주세요.",
-  emailCodeCheckInvalid: "이메일 인증번호가 일치하지 않습니다.",
+  emailCodeSentFailed: '이메일 인증번호 전송에 실패했습니다.',
+  emailCodeInvalid: '이메일 인증번호는 6자리의 숫자입니다.',
+  emailCodeRequired: '이메일 인증번호를 입력해주세요.',
+  emailCodeCheckInvalid: '이메일 인증번호가 일치하지 않습니다.',
 
   /** 비밀번호 변경 */
-  passwordCheckInvalid:
-    "비밀번호 양식이 올바르지 않거나, 비밀번호가 일치하지 않습니다.",
-  emailCheckInvalid: "존재하는 아이디가 없습니다.",
-  emailPhoneNumberNotMatched: "이메일과 휴대전화 번호가 일치하지 않습니다.",
+  passwordCheckInvalid: '비밀번호 양식이 올바르지 않거나, 비밀번호가 일치하지 않습니다.',
+  emailCheckInvalid: '존재하는 아이디가 없습니다.',
+  emailPhoneNumberNotMatched: '이메일과 휴대전화 번호가 일치하지 않습니다.',
 
   /** 롤링페이퍼 */
-  paperNameRequired: "롤링페이퍼 이름을 입력해주세요.",
-  paperDescriptionRequired: "롤링페이퍼 설명을 입력해주세요.",
-  paperOpenDateRequired: "롤링페이퍼 오픈 날짜를 입력해주세요.",
+  paperNameRequired: '롤링페이퍼 이름을 입력해주세요.',
+  paperDescriptionRequired: '롤링페이퍼 설명을 입력해주세요.',
+  paperOpenDateRequired: '롤링페이퍼 오픈 날짜를 입력해주세요.',
 
   /** 기타 */
-  blockRecirect:
-    "작성하신 내용이 저장되지 않았습니다. 이 페이지를 떠나시겠습니까?",
+  blockRecirect: '작성하신 내용이 저장되지 않았습니다. 이 페이지를 떠나시겠습니까?',
 
   /** 권한 에러 */
-  unauthorized: "로그인이 필요합니다.",
-  forbidden: "접근 권한이 없습니다.",
+  unauthorized: '로그인이 필요합니다.',
+  forbidden: '접근 권한이 없습니다.',
 
-  updateFailure: "수정에 실패하였습니다.",
+  updateFailure: '수정에 실패하였습니다.',
 };
 
 export const HELPER_MESSAGES = {
   /** 유저 관련 */
-  userDeleteSuccess: "해당 회원이 탈퇴되었습니다.",
+  userDeleteSuccess: '해당 회원이 탈퇴되었습니다.',
 
   /** Auth Form 관련 */
-  emailValid: "사용 가능한 이메일입니다.",
-  passwordValid: "사용 가능한 비밀번호입니다.",
-  passwordConfirmValid: "비밀번호가 일치합니다.",
+  emailValid: '사용 가능한 이메일입니다.',
+  passwordValid: '사용 가능한 비밀번호입니다.',
+  passwordConfirmValid: '비밀번호가 일치합니다.',
 
   /** 비밀번호 변경 */
-  emailCheckValid: "이메일이 확인되었습니다.",
-  passwordChangeSuccess: "비밀번호 변경이 완료되었습니다.",
+  emailCheckValid: '이메일이 확인되었습니다.',
+  passwordChangeSuccess: '비밀번호 변경이 완료되었습니다.',
 
   /** 본인 인증 */
-  emailCodeSentSuccess: "이메일로 인증번호가 전송되었습니다.",
-  emailCodeCheckSuccess: "인증번호가 확인되었습니다.",
+  emailCodeSentSuccess: '이메일로 인증번호가 전송되었습니다.',
+  emailCodeCheckSuccess: '인증번호가 확인되었습니다.',
 
   /** 로그인 */
-  loginSuccess: "로그인 되었습니다.",
-  logoutSuccess: "로그아웃 되었습니다.",
+  loginSuccess: '로그인 되었습니다.',
+  logoutSuccess: '로그아웃 되었습니다.',
 
-  updateSuccess: "수정이 완료되었습니다.",
+  userInfoUpdateSuccess: '유저 정보 수정이 완료되었습니다.',
 };


### PR DESCRIPTION
## 👍🏻 구현 기능
1. 비밀번호, 비밀번호 확인 숨김 처리
2.  '완료' 버튼에 validation 추가
3. 기본값으로 유저 기존 정보 넣어줬습니다
4. onMutation에서 refetch하여 마이페이지로 넘어갔을 때 바로 반영되게 했습니다 (thx to @wherewhale )
5. 소셜 로그인 여부에 따라 카카오 심볼 등장



## 🍄 화면 이미지
### 1번+2번
<img width="461" alt="스크린샷 2025-06-17 오후 4 49 39" src="https://github.com/user-attachments/assets/08496a66-2e32-4ab8-8843-678c28a78072" />
<img width="461" alt="스크린샷 2025-06-17 오후 4 49 54" src="https://github.com/user-attachments/assets/8fa35308-342d-4360-b6a4-3d66d8a0f2b3" />


### 4번
- 소셜 로그인
<img width="1129" alt="스크린샷 2025-06-17 오후 5 18 52" src="https://github.com/user-attachments/assets/0c905f63-0c97-4984-b19a-356189a6bacf" />

- 일반 로그인
<img width="1129" alt="스크린샷 2025-06-17 오후 5 25 41" src="https://github.com/user-attachments/assets/9d482e79-a542-4c12-a694-11de4f82ba76" />

