### PR TITLE
[fix] 로그인 UX 이슈(#40) 해결

### DIFF
--- a/apps/client/src/containers/auth/login/id/index.tsx
+++ b/apps/client/src/containers/auth/login/id/index.tsx
@@ -2,9 +2,19 @@ import { SupportMenu } from "@/components/auth/SupportMenu";
 import { useLoginForm } from "@/hooks/form/useLoginForm";
 import { ERROR_MESSAGES } from "@libs/utils/message";
 import { Typography, TextField, PasswordField, Button } from "@ui/components";
+import { useEffect } from "react";
 
 const AuthLoginIdContainer = () => {
-  const { register, handleSubmit, watch, errors, onSubmit } = useLoginForm();
+  const { register, handleSubmit, watch, errors, onSubmit, clearErrors } =
+    useLoginForm();
+
+  const ID = watch("id");
+  useEffect(() => {
+    if (ID) {
+      clearErrors("password");
+    }
+  }, [ID]);
+
   return (
     <div>
       <Typography variant="b20" className="mt-10">

--- a/apps/client/src/hooks/form/useLoginForm.ts
+++ b/apps/client/src/hooks/form/useLoginForm.ts
@@ -19,6 +19,7 @@ export const useLoginForm = () => {
     handleSubmit,
     watch,
     setError,
+    clearErrors,
     formState: { errors },
   } = useForm<CommonLoginForm>({
     mode: "onChange",
@@ -65,5 +66,6 @@ export const useLoginForm = () => {
     watch,
     errors,
     onSubmit,
+    clearErrors,
   };
 };


### PR DESCRIPTION
## 변경사항

일반 로그인 실패 시, 아이디를 수정해도 완료 버튼이 활성화 되지 않는 문제
- 원인: 아이디와 비밀번호 둘 중 하나로 오류가 나더라도 password 에러로 통합 처리 했기 때문
- 해결방법: useForm의 clearErrors를 사용하여, 페이지 렌더링 시 아이디 값이 있으면 "password"로 등록된 에러를 삭제

## 이미지
- 변경 전
![456895270-93db298a-f05e-49f2-a087-93b5ee6f16fa](https://github.com/user-attachments/assets/019fd75e-6abb-4a8b-9e3e-94a36435e246)

- 변경 후 

로그인 실패 상태 
<img width="474" alt="스크린샷 2025-06-20 오후 4 59 19" src="https://github.com/user-attachments/assets/7fa9b69f-16e3-44d0-8abd-858fd29c8131" />

아이디만 수정해도 완료 버튼 재활성화 성공
<img width="474" alt="스크린샷 2025-06-20 오후 4 59 52" src="https://github.com/user-attachments/assets/dd158284-bc73-4f87-a954-402e81b83376" />
