### PR TITLE
[fix] 개인 정보 수정 페이지 - 이름 변경 validation 추가 #67

### DIFF
--- a/apps/client/src/containers/my-page/edit-profile/EditProfile.tsx
+++ b/apps/client/src/containers/my-page/edit-profile/EditProfile.tsx
@@ -24,6 +24,7 @@ import { useMutation } from "@tanstack/react-query";
 import { ErrorDTO } from "@/types/error";
 import { AxiosError, isAxiosError } from "axios";
 import { UpdateUserInfoRequest } from "@/types/user";
+import { KOREAN_NAME_REGEX } from "@libs/constants/regex";
 
 const EditProfileContainer = () => {
   const { register, handleSubmit, watch, errors } = useEditProfileForm();
@@ -95,6 +96,11 @@ const EditProfileContainer = () => {
           gutterBottom
           {...register("name", {
             required: ERROR_MESSAGES.usernameRequired,
+            validate: (value) => {
+              if (!KOREAN_NAME_REGEX.test(value)) {
+                return ERROR_MESSAGES.usernameInvalid;
+              }
+            },
           })}
         />
         {!isSocialUser && (


### PR DESCRIPTION
이슈 번호 #67 

## 변경사항
회원 가입 당시에 걸려있던 한글 유효성 검사 추가

### - 변경 후
<img width="507" alt="스크린샷 2025-06-24 오후 1 37 31" src="https://github.com/user-attachments/assets/05cba673-1b9c-4060-bb17-6e01cbc0558c" />
<img width="507" alt="스크린샷 2025-06-24 오후 1 37 23" src="https://github.com/user-attachments/assets/8ff6b0f2-2caa-4d07-9296-f3378e8d2617" />
<img width="507" alt="스크린샷 2025-06-24 오후 1 37 35" src="https://github.com/user-attachments/assets/dcd51e1c-320b-4abf-b931-51c3ac156c93" />
