### PR TITLE
[fix] 보낸 메시지 새로고침 이슈 해결 #60

### DIFF
--- a/apps/client/src/containers/paper/detail/Receive.tsx
+++ b/apps/client/src/containers/paper/detail/Receive.tsx
@@ -45,8 +45,6 @@ const PaperDetailReceiveContainer: React.FC<Props> = ({
     getNextPageParam: (lastPage) => {
       return lastPage.message.hasNext ? lastPage.message.nextCursor : undefined;
     },
-    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
-    refetchOnWindowFocus: false, // 윈도우 포커스 시 재조회 하지 않음
     retry: false, // 실패 시 재시도 하지 않음
   });
 

--- a/apps/client/src/containers/paper/detail/Send.tsx
+++ b/apps/client/src/containers/paper/detail/Send.tsx
@@ -40,8 +40,6 @@ const PaperDetailSendContainer: React.FC<Props> = ({ paperData, paperId }) => {
     getNextPageParam: (lastPage) => {
       return lastPage.message.hasNext ? lastPage.message.nextCursor : undefined;
     },
-    staleTime: 0, // 5분 동안 캐시 유지
-    refetchOnWindowFocus: false, // 윈도우 포커스 시 재조회 하지 않음
     retry: false, // 실패 시 재시도 하지 않음
   });
 

--- a/apps/client/src/containers/paper/detail/Send.tsx
+++ b/apps/client/src/containers/paper/detail/Send.tsx
@@ -40,7 +40,7 @@ const PaperDetailSendContainer: React.FC<Props> = ({ paperData, paperId }) => {
     getNextPageParam: (lastPage) => {
       return lastPage.message.hasNext ? lastPage.message.nextCursor : undefined;
     },
-    staleTime: 1000 * 60 * 5, // 5분 동안 캐시 유지
+    staleTime: 0, // 5분 동안 캐시 유지
     refetchOnWindowFocus: false, // 윈도우 포커스 시 재조회 하지 않음
     retry: false, // 실패 시 재시도 하지 않음
   });


### PR DESCRIPTION
#60 

## 변경사항

캐시 유지 시간인 staleTime을 0으로 수정하여 메시지 작성, 수정, 삭제 이후 변경사항 바로 보이게 변경

- 변경 전 : 메시지 작성했음에도 새로고침을 하기 전에는 반영이 안되는 모습
<img width="507" alt="스크린샷 2025-06-25 오후 1 29 56" src="https://github.com/user-attachments/assets/a5ae2584-ca9d-4881-b1cd-ac5ac2e736e0" />

- 변경 후 :
<메시지 작성>
<img width="507" alt="스크린샷 2025-06-25 오후 1 30 30" src="https://github.com/user-attachments/assets/10db1d2f-4317-4a84-9079-6da50163b5f8" />

<메시지 수정>
<img width="507" alt="스크린샷 2025-06-25 오후 1 30 48" src="https://github.com/user-attachments/assets/dd1c21dd-2163-4111-b31b-9dc1d7d5b753" />

<메시지 삭제>
<img width="507" alt="스크린샷 2025-06-25 오후 1 30 57" src="https://github.com/user-attachments/assets/f04439ea-4637-4cbb-9842-a2cb97bf48d7" />
